### PR TITLE
[READY] - Leverage correct url event param

### DIFF
--- a/src/standardize.js
+++ b/src/standardize.js
@@ -4,7 +4,7 @@ function standardizeIssueComment(event) {
     comments_url: event.issue.comments_url,
     issue_number: event.issue.number,
     repository_url: event.issue.repository_url,
-    url: event.issue.pull_request.url,
+    url: event.issue.url,
   };
 }
 


### PR DESCRIPTION
## Description

An issue comment was erroring with an error: `Cannot read properties of undefined (reading 'url')` while PR comments were working as expected. See an example: https://github.com/socallinuxexpo/scale-network/actions/runs/6291482569

## Tests

- Confirm that PR comments work: https://github.com/socallinuxexpo/scale-network/actions/runs/6299070552/job/17099125555
- Confirm that issue comments work: https://github.com/socallinuxexpo/scale-network/actions/runs/6299272622